### PR TITLE
Fix: use full path to schemas in config

### DIFF
--- a/heal/vlmd/config.py
+++ b/heal/vlmd/config.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 # file prefix
 OUTPUT_FILE_PREFIX = "heal-dd"
@@ -10,13 +11,15 @@ ALLOWED_SCHEMA_TYPES = ["auto", "csv", "json", "tsv"]
 ALLOWED_OUTPUT_TYPES = ["csv", "json"]
 
 # schemas
-csv_schema_file = "heal/vlmd/schemas/heal_csv.json"
-with open(csv_schema_file, "r") as f:
-    CSV_SCHEMA = json.load(f)
+schema_dir_path = Path(__file__).parents[1].joinpath("vlmd/schemas")
 
-json_schema_file = "heal/vlmd/schemas/heal_json.json"
-with open(json_schema_file, "r") as f:
-    JSON_SCHEMA = json.load(f)
+csv_schema_path = schema_dir_path.joinpath("heal_csv.json")
+with open(csv_schema_path, "r") as schema_file:
+    CSV_SCHEMA = json.load(schema_file)
+
+json_schema_path = schema_dir_path.joinpath("heal_json.json")
+with open(json_schema_path, "r") as schema_file:
+    JSON_SCHEMA = json.load(schema_file)
 
 # schema
 JSON_SCHEMA_VERSION = JSON_SCHEMA.get("version", "0.3.2")


### PR DESCRIPTION
This branch can be installed into a virtual environment with

```
pip install -e git+https://github.com/uc-cdis/heal-platform-sdk.git@fix/use-full-path-to-schemas#egg=heal
```

### New Features

### Breaking Changes

### Bug Fixes

* Use full path to schema files in config

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
