### PR TITLE
Fix to disallow additional properties in nested fields, eg, constraints

### DIFF
--- a/heal/vlmd/schemas/heal_json.json
+++ b/heal/vlmd/schemas/heal_json.json
@@ -167,6 +167,7 @@
                     },
                     "constraints": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "required": {
                                 "type": "boolean",
@@ -293,11 +294,13 @@
                         "description": "A set of instrument and item references to standardized data elements designed to document the [HEAL common data elements program](https://heal.nih.gov/data/common-data-elements) and other standardized/common element sources to facilitate cross-study comparison and interoperability of data. One can either map an individual data element or an instrument in which the field is a part of. __**All Fields Mapped (Both Instrument and Item)**__ ```json \"standardsMappings\": [    {        \"instrument\": {            \"url\": \"https://www.heal.nih.gov/files/CDEs/2023-05/adult-demographics-cdes.xlsx\",            \"source\": \"heal-cde\",            \"title\": \"adult-demographics\",            \"id\": \"5141\"        },        \"item\": {            \"url\": \"https://evs.nci.nih.gov/ftp1/CDISC/SDTM/SDTM%20Terminology.html#CL.C74457.RACE\",            \"source\": \"CDISC\",            \"id\": \"C74457\"        }    } ] ``` __**Only Instrument Title of Form CDE File Mapped**__ In this scenario, especially as CDE variables do not have associated CDISC ids listed, only instrument information is given. ```json \"standardsMappings\": [    {        \"instrument\": {            \"source\": \"heal-cde\",            \"title\": \"Adult demographics\"        }    } ] ``` __**Only Instrument ID of HEAL CDE Mapped**__ ```json \"standardsMappings\": [    {        \"instrument\": {            \"source\": \"heal-cde\",            \"id\": \"5141\"        }    } ] ``` __**Other Non-HEAL CDE Use Cases**__ Only item matched (for example if found in the NIH (not HEAL) CDE repository). Folks would enter the information in the \"Identifier\" section. Similar to the above, they could also just enter the \"url\". ```json \"standardsMappings\": [    {        \"item\": {            \"source\": \"NLM\",            \"id\": \"Fakc6Jy2x\"        }    } ] ``` __**Multiple CDE Mappings**__ Two separate records. If desired, multiple standard mappings can be entered, say from the NIH HEAL CDE repo and the NIH CDE lookup (NLM) by way of two separate records in the list. ```json \"standardsMappings\": [    {        \"instrument\": {            \"source\": \"heal-cde\",            \"title\": \"Adult demographics\"        },        \"item\": {            \"source\": \"CDISC\",            \"id\": \"C74457\"        },    },    {        \"item\": {            \"source\": \"NLM\",            \"id\": \"Fakc6Jy2x\"        }    } ] ```",
                         "items": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "instrument": {
                                     "type": "object",
                                     "title": "Standard mapping - instrument",
                                     "description": "A standardized set of items which encompass a variable in this variable level metadata document (if at the root level or the document level) or the individual variable (if at the field level). !!! note \"NOTE\" If information is present at both the root and the field level,   then the information at the field level would take precedence (i.e., it would cascade).",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "url": {
                                             "title": "Url",
@@ -338,6 +341,7 @@
                                     "type": "object",
                                     "title": "Standards mappings - Item",
                                     "description": "A standardized item (i.e., field, variable etc) mapped to this individual variable.",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "url": {
                                             "title": "Standards mappings - Url",
@@ -375,6 +379,7 @@
                         "type": "array",
                         "items": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "url": {
                                     "title": "Related Concepts - Url",


### PR DESCRIPTION
The  current `fields`-level specification of

`"additionalProperties": false,`

applies to a single level in our version of jsonschema. In newer versions the specification automatically applies to nested levels. In our version it does not apply to sub-levels such as `constraints`.

In the above, `additionalProperties` means any properties present in the file that are not part of the schema.

Additional properties under `constraints` are not checked in the validation process. They simply get passed through in the extraction process. A file with `constraints.enumLabels` and `constraints.foo` does not raise an error. The columns get passed through and they appear in converted files. 

If we want to disallow any additionalProperties in sub-levels (eg, constraints, StandardMappings) then we need to insert specifications in the sub-levels. 

This branch has additional specifications in the sub-levels in the schema for json. Files with `constraints.enumLabels` and `constraints.foo` will raise an error and will not generate converted output files. 


### New Features

### Breaking Changes

### Bug Fixes

* Explicitly disallow additional properties under nested fields

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
