### PR TITLE
Raise Exception if unable to parse string item

### DIFF
--- a/heal/vlmd/extract/csv_dict_conversion.py
+++ b/heal/vlmd/extract/csv_dict_conversion.py
@@ -25,6 +25,7 @@ def _parse_string_objects(
     """Parse string objects and array to create the dict (json) instance"""
     tbl_json = tbl_csv.copy()
     for column_name in tbl_json.columns.tolist():
+        logger.debug(f"Working on column '{column_name}'")
         # NOTE: the below methodology uses the schema to instruct how to convert to json.
         field_prop_name = utils.find_prop_name(column_name, field_properties)
         field_prop = field_properties.get(field_prop_name)
@@ -242,7 +243,6 @@ def convert_datadict_csv(
                 tbl_csv[new_column_name] = tbl_csv[new_column_name].replace(
                     item_sep, "|"
                 )
-
     tbl_json = _parse_string_objects(tbl_csv, field_properties)
 
     # drop all custom columns (as I have nested already)

--- a/heal/vlmd/extract/utils.py
+++ b/heal/vlmd/extract/utils.py
@@ -98,10 +98,18 @@ def strip_html(html_string):
         return html_string
 
 
-def parse_dictionary_str(string, item_sep, key_val_sep):
+def parse_dictionary_str(string, item_sep, key_val_sep) -> dict:
     """
     Parses a stringified dictionary into a dictionary
     based on item separator
+
+    Args
+        string (str) - the input string of separated key-value pairs, eg "1=yes|2=No"
+        item_sep (str) - item separator, "|"
+        key_val_sep (str) - "="
+
+    Returns
+        dictionary of keys and values if valid input
     """
     if string != "" and string is not None:
         str_items = string.strip().split(item_sep)
@@ -109,6 +117,10 @@ def parse_dictionary_str(string, item_sep, key_val_sep):
 
         for str_item in str_items:
             if str_item:
+                if key_val_sep not in str_item:
+                    raise Exception(
+                        f"Value separator '{key_val_sep}' not present in string item '{str_item}'"
+                    )
                 item = str_item.split(key_val_sep, 1)
                 items[item[0].strip()] = item[1].strip()
 

--- a/tests/test_vlmd_extract_utils.py
+++ b/tests/test_vlmd_extract_utils.py
@@ -271,6 +271,18 @@ def test_parse_dictionary_str():
     assert output_dict == expected_dict
 
 
+def test_parse_dictionary_str_missing_separator():
+    """Test that an Exception is raised for a missing key_val_separator"""
+    input_string = "1 = Yes | 2 - No"
+    key_val_sep = "="
+    with pytest.raises(Exception) as err:
+        parse_dictionary_str(input_string, item_sep="|", key_val_sep=key_val_sep)
+    expected_error_message = (
+        f"Value separator '{key_val_sep}' not present in string item ' 2 - No'"
+    )
+    assert expected_error_message in str(err.value)
+
+
 @pytest.mark.parametrize(
     "input_string, separator, expected_output_list",
     [


### PR DESCRIPTION

Motivated by files with typos related to this ticket: [HP-1870](https://ctds-planx.atlassian.net/browse/HP-1870)

Unhandled exceptions in parsing of input was giving a generic python error for `list index out of range`. 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

* an Exception is raised if key-value strings in csv fields cannot be parsed. A new error message includes the string input. 

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
