### PR TITLE
Specify the columns for redcap pandas 'replace'

### DIFF
--- a/heal/vlmd/extract/redcap_csv_dict_conversion.py
+++ b/heal/vlmd/extract/redcap_csv_dict_conversion.py
@@ -47,7 +47,11 @@ def rename_and_fill(source_dataframe) -> list[dict]:
 
     # downfill section (if blank -- given we read in with petl, blanks are "" but ffill takes in np.nan)
     source_dataframe["section"] = (
-        source_dataframe.replace({"": np.nan}).groupby("form")["section"].ffill()
+        source_dataframe.assign(
+            section=source_dataframe["section"].replace({"": np.nan})
+        )
+        .groupby("form")["section"]
+        .ffill()
     )
     # Recover any remaining np.nan (ie, not converted by 'ffill') back to "".
     # Include the 'infer_objects' method as described here


### PR DESCRIPTION
Pandas gives a deprecation warning for `replace` when extracting from a REDCap csv dictionary

/opt/conda/lib/python3.9/site-packages/heal/vlmd/extract/redcap_csv_dict_conversion.py:50: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  source_dataframe.replace({"": np.nan}).groupby("form")["section"].ffill()

  
The `infer_objects()` doesn't suppress the warning. Instead, specifying the `section` column suppresses the warning (and the `infer_objects()` is not needed).


### New Features

### Breaking Changes

### Bug Fixes

### Improvements

* Specify columns for pandas `replace` for REDCap dictionary conversion

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
